### PR TITLE
Adjustments to support installations without fast_404 with no failures

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -22,7 +22,6 @@ $contrib_path = 'sites/all/modules/contrib';
 // @see https://govdex.gov.au/jira/browse/GOVCMS-993
 // @see https://github.com/drupal/drupal/blob/7.x/sites/default/default.settings.php#L518
 // @see https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/drupal_fast_404/7.x
-include_once($contrib_path . '/fast_404/fast_404.inc');
 $conf['fast_404_exts'] = '/^(?!robots)^(?!sites\/default\/files\/private).*\.(?:png|gif|jpe?g|svg|tiff|bmp|raw|webp|docx?|xlsx?|pptx?|swf|flv|cgi|dll|exe|nsf|cfm|ttf|bat|pl|asp|ics|rtf)$/i';
 $conf['fast_404_html'] = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>';
 $conf['fast_404_string_whitelisting'] = array('robots.txt', 'system/files');
@@ -57,8 +56,12 @@ class govCms404Page {
   }
 }
 
-$conf['404_fast_html'] = new govCms404Page($conf['fast_404_html']);
-fast_404_ext_check();
+// Import Fast404 settings only when the Drupal module is found.
+if (file_exists($contrib_path . '/fast_404/fast_404.inc')) {
+  include_once($contrib_path . '/fast_404/fast_404.inc');
+  $conf['404_fast_html'] = new govCms404Page($conf['fast_404_html']);
+  fast_404_ext_check();
+}
 
 // Ensure redirects created with the redirect module are able to set appropriate
 // caching headers to ensure that Varnish and Akamai can cache the HTTP 301.


### PR DESCRIPTION
The following error is produced when this scaffold is used locally where `fast_404` is absent.

```
PHP Fatal error:  Uncaught Error: Call to undefined function cache_get() in /app/docroot/includes/module.inc:762
Stack trace:
#0 /app/docroot/includes/module.inc(962): module_implements('system_theme_in...')
#1 /app/docroot/modules/system/system.module(2514): module_invoke_all('system_theme_in...')
#2 /app/docroot/includes/theme.inc(798): _system_rebuild_theme_data()
#3 /app/docroot/includes/theme.maintenance.inc(57): list_themes()
#4 /app/docroot/includes/bootstrap.inc(2894): _drupal_maintenance_theme()
#5 /app/docroot/includes/errors.inc(179): drupal_maintenance_theme()
#6 /app/docroot/includes/bootstrap.inc(2622): _drupal_log_error(Array, true)
#7 [internal function]: _drupal_exception_handler(Object(Error))
#8 {main}
  thrown in /app/docroot/includes/module.inc on line 762
Drush command terminated abnormally due to an unrecoverable error.       [error]
Error: Uncaught Error: Call to undefined function cache_get() in
/app/docroot/includes/module.inc:762
Stack trace:
#0 /app/docroot/includes/module.inc(962):
module_implements('system_theme_in...')
#1 /app/docroot/modules/system/system.module(2514):
module_invoke_all('system_theme_in...')
#2 /app/docroot/includes/theme.inc(798): _system_rebuild_theme_data()
#3 /app/docroot/includes/theme.maintenance.inc(57): list_themes()
#4 /app/docroot/includes/bootstrap.inc(2894):
_drupal_maintenance_theme()
#5 /app/docroot/includes/errors.inc(179): drupal_maintenance_theme()
#6 /app/docroot/includes/bootstrap.inc(2622):
_drupal_log_error(Array, true)
#7 [internal function]: _drupal_exception_handler(Object(Error))
#8 {main}
  thrown in /app/docroot/includes/module.inc, line 762
```

## To reproduce

1. Clone this repository
2. Copy a downloaded govcms (7) distribution into the `docroot` directory.
3. Run `ahoy build`
4. Run `ahoy up`
5. Run `ahoy drush`

## What this does

* Puts a safeguard in place to prevent including files which may not exist
* Puts a safeguard in place which wraps the initialisation
* Uses code which doesn't require full bootstrap - `drupal_get_path` or `module_exists` would have been nice for example - but it wasn't an option without bootstrap.
* Prevents WSOD (white screen of death) and pretty massive fatal errors (as described above) from appearing so the installation screen can occur - or the site can be installed using drush. _Currently_, the site cannot be installed via UI or drush because of the missing module.

## Notes

* Due to architecture this doesn't impact remote sites, but _could_ affect local sites and does affect this project when used vanilla.