### PR TITLE
Updated scaffold to reflect docker hub pull limits, fix to --quiet option

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,9 @@
-image: quay.io/govcms/govcms-ci
+image: gitlab-registry-production.govcms.amazee.io/govcms/govcms-ci${GOVCMS_CI_IMAGE_VERSION}
 services:
-- docker:dind
+  - gitlab-registry-production.govcms.amazee.io/govcms/govcms-ci/dind:latest
 stages:
-- build
-- deploy
+  - build
+  - deploy
 build:
   stage: build
   script:
@@ -13,7 +13,7 @@ build:
   - ahoy up
   - docker-compose exec -T test dockerize -wait tcp://mariadb:3306 -timeout 1m
   - |
-    if grep --quiet '^MARIADB_DATA_IMAGE' .env; then
+    if grep -q '^MARIADB_DATA_IMAGE' .env; then
       ahoy govcms-deploy
     else
       ahoy -v install

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 image: gitlab-registry-production.govcms.amazee.io/govcms/govcms-ci${GOVCMS_CI_IMAGE_VERSION}
 services:
-  - gitlab-registry-production.govcms.amazee.io/govcms/govcms-ci/dind:latest
+  - name: gitlab-registry-production.govcms.amazee.io/govcms/govcms-ci/dind:latest
+    command: ["--tls=false"]
 stages:
   - build
   - deploy


### PR DESCRIPTION
Recent changes by docker hub prevent builds due to pull limit reached.
Error observed in GitLab CI during build: 
`Cannot connect to the Docker daemon at tcp://localhost:2375. Is the docker daemon running?`

Another error corrected in CI builds:
`$ if grep --quiet '^MARIADB_DATA_IMAGE' .env; then # collapsed multi-line command`
`grep: unrecognized option: quiet`